### PR TITLE
Filter: Fix ENTRYPOINT

### DIFF
--- a/filter/Dockerfile
+++ b/filter/Dockerfile
@@ -21,4 +21,4 @@ ENV PATH="/usr/local/bin:${PATH}"
 
 COPY bin /usr/local/bin/
 
-ENTRYPOINT sh -c
+ENTRYPOINT ["sh", "-c"]


### PR DESCRIPTION
Currently getting an error with this:

```
sh: 0: -c requires an argument
```