### PR TITLE
Update exit codes for filter so that steps that don't match aren't failed.

### DIFF
--- a/filter/Dockerfile
+++ b/filter/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stable-slim
 
 LABEL "name"="filter"
 LABEL "maintainer"="GitHub Actions <support+actions@github.com>"
-LABEL "version"="1.0.2"
+LABEL "version"="1.1.0"
 
 LABEL "com.github.actions.name"="Filters for GitHub Actions"
 LABEL "com.github.actions.description"="Common filters to stop workflows"

--- a/filter/bin/action
+++ b/filter/bin/action
@@ -12,5 +12,5 @@ actual=$(jq -r .action "$GITHUB_EVENT_PATH")
 
 echo "$actual" | grep -Eq "^$expected$" || {
   echo "action is \"$actual\", not \"$expected\""
-  exit 76
+  exit 78
 }

--- a/filter/bin/action
+++ b/filter/bin/action
@@ -12,5 +12,5 @@ actual=$(jq -r .action "$GITHUB_EVENT_PATH")
 
 echo "$actual" | grep -Eq "^$expected$" || {
   echo "action is \"$actual\", not \"$expected\""
-  exit 1
+  exit 76
 }

--- a/filter/bin/label
+++ b/filter/bin/label
@@ -14,6 +14,6 @@ matches=$(jq -r "$filter" "$GITHUB_EVENT_PATH")
 for label in "$@"; do
   echo "$matches" | grep -Eq "^$label$" || {
     echo "label \"$label\", does not match \"$matches\""
-    exit 76
+    exit 78
   }
 done

--- a/filter/bin/label
+++ b/filter/bin/label
@@ -12,5 +12,8 @@ fi
 matches=$(jq -r "$filter" "$GITHUB_EVENT_PATH")
 
 for label in "$@"; do
-  echo "$matches" | grep -Eq "^$label$"
+  echo "$matches" | grep -Eq "^$label$" || {
+    echo "label \"$label\", does not match \"$matches\""
+    exit 76
+  }
 done

--- a/filter/bin/ref
+++ b/filter/bin/ref
@@ -15,5 +15,5 @@ case "$GITHUB_REF" in
     ;;
   *)
     echo "$GITHUB_REF does not match $pattern"
-    exit 76
+    exit 78
 esac

--- a/filter/bin/ref
+++ b/filter/bin/ref
@@ -15,5 +15,5 @@ case "$GITHUB_REF" in
     ;;
   *)
     echo "$GITHUB_REF does not match $pattern"
-    exit 1
+    exit 76
 esac

--- a/filter/test/action.bats
+++ b/filter/test/action.bats
@@ -14,7 +14,7 @@ export GITHUB_EVENT_PATH="$BATS_TEST_DIRNAME/fixtures/event.json"
 
 @test "action: does not match" {
   run action edited
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 76 ]
   echo $output
   [ "$output" = "action is \"created\", not \"edited\"" ]
 }
@@ -29,6 +29,6 @@ export GITHUB_EVENT_PATH="$BATS_TEST_DIRNAME/fixtures/event.json"
 @test "action: does not match a or b" {
   run action "edited|deleted"
   echo $output
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 76 ]
   [ "$output" = "action is \"created\", not \"edited|deleted\"" ]
 }

--- a/filter/test/action.bats
+++ b/filter/test/action.bats
@@ -14,7 +14,7 @@ export GITHUB_EVENT_PATH="$BATS_TEST_DIRNAME/fixtures/event.json"
 
 @test "action: does not match" {
   run action edited
-  [ "$status" -eq 76 ]
+  [ "$status" -eq 78 ]
   echo $output
   [ "$output" = "action is \"created\", not \"edited\"" ]
 }
@@ -29,6 +29,6 @@ export GITHUB_EVENT_PATH="$BATS_TEST_DIRNAME/fixtures/event.json"
 @test "action: does not match a or b" {
   run action "edited|deleted"
   echo $output
-  [ "$status" -eq 76 ]
+  [ "$status" -eq 78 ]
   [ "$output" = "action is \"created\", not \"edited|deleted\"" ]
 }

--- a/filter/test/branch.bats
+++ b/filter/test/branch.bats
@@ -21,7 +21,7 @@ PATH="$PATH:$BATS_TEST_DIRNAME/../bin"
 @test "branch: ref is a tag" {
   export GITHUB_REF=refs/tags/v1.2.3
   run branch
-  [ "$status" -eq 76 ]
+  [ "$status" -eq 78 ]
   [ "$output" = "refs/tags/v1.2.3 does not match refs/heads/*" ]
 }
 
@@ -32,14 +32,14 @@ PATH="$PATH:$BATS_TEST_DIRNAME/../bin"
   [ "$output" = "refs/heads/release-v2.14 matches refs/heads/release-*" ]
 
   run branch stale*
-  [ "$status" -eq 76 ]
+  [ "$status" -eq 78 ]
   [ "$output" = "refs/heads/release-v2.14 does not match refs/heads/stale*" ]
 }
 
 @test "branch: does not match substring" {
   export GITHUB_REF=refs/heads/the-masters-tournament
   run branch master
-  [ "$status" -eq 76 ]
+  [ "$status" -eq 78 ]
   [ "$output" = "refs/heads/the-masters-tournament does not match refs/heads/master" ]
 
   run branch *master*

--- a/filter/test/branch.bats
+++ b/filter/test/branch.bats
@@ -21,7 +21,7 @@ PATH="$PATH:$BATS_TEST_DIRNAME/../bin"
 @test "branch: ref is a tag" {
   export GITHUB_REF=refs/tags/v1.2.3
   run branch
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 76 ]
   [ "$output" = "refs/tags/v1.2.3 does not match refs/heads/*" ]
 }
 
@@ -32,14 +32,14 @@ PATH="$PATH:$BATS_TEST_DIRNAME/../bin"
   [ "$output" = "refs/heads/release-v2.14 matches refs/heads/release-*" ]
 
   run branch stale*
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 76 ]
   [ "$output" = "refs/heads/release-v2.14 does not match refs/heads/stale*" ]
 }
 
 @test "branch: does not match substring" {
   export GITHUB_REF=refs/heads/the-masters-tournament
   run branch master
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 76 ]
   [ "$output" = "refs/heads/the-masters-tournament does not match refs/heads/master" ]
 
   run branch *master*

--- a/filter/test/label.bats
+++ b/filter/test/label.bats
@@ -18,10 +18,10 @@ export GITHUB_EVENT_PATH="$BATS_TEST_DIRNAME/fixtures/event.json"
 
 @test "label: does not match" {
   run label feature
-  [ "$status" -eq 76 ]
+  [ "$status" -eq 78 ]
 }
 
 @test "label: does not match all" {
   run label urgent feature
-  [ "$status" -eq 76 ]
+  [ "$status" -eq 78 ]
 }

--- a/filter/test/label.bats
+++ b/filter/test/label.bats
@@ -18,10 +18,10 @@ export GITHUB_EVENT_PATH="$BATS_TEST_DIRNAME/fixtures/event.json"
 
 @test "label: does not match" {
   run label feature
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 76 ]
 }
 
 @test "label: does not match all" {
   run label urgent feature
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 76 ]
 }

--- a/filter/test/tag.bats
+++ b/filter/test/tag.bats
@@ -23,7 +23,7 @@ PATH="$PATH:$BATS_TEST_DIRNAME/../bin"
   export GITHUB_REF=refs/heads/master
   run tag
   echo output: $output
-  [ "$status" -eq 76 ]
+  [ "$status" -eq 78 ]
   [ "$output" = "refs/heads/master does not match refs/tags/*" ]
 }
 
@@ -34,6 +34,6 @@ PATH="$PATH:$BATS_TEST_DIRNAME/../bin"
   [ "$output" = "refs/tags/v1.2.3 matches refs/tags/v1*" ]
 
   run tag release*
-  [ "$status" -eq 76 ]
+  [ "$status" -eq 78 ]
   [ "$output" = "refs/tags/v1.2.3 does not match refs/tags/release*" ]
 }

--- a/filter/test/tag.bats
+++ b/filter/test/tag.bats
@@ -23,7 +23,7 @@ PATH="$PATH:$BATS_TEST_DIRNAME/../bin"
   export GITHUB_REF=refs/heads/master
   run tag
   echo output: $output
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 76 ]
   [ "$output" = "refs/heads/master does not match refs/tags/*" ]
 }
 
@@ -34,6 +34,6 @@ PATH="$PATH:$BATS_TEST_DIRNAME/../bin"
   [ "$output" = "refs/tags/v1.2.3 matches refs/tags/v1*" ]
 
   run tag release*
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 76 ]
   [ "$output" = "refs/tags/v1.2.3 does not match refs/tags/release*" ]
 }


### PR DESCRIPTION
Actions have been updated so that an exit code of `78` can be used to signal that an Action should stop execution, but not cause the entire workflow to fail.  This PR updates the filter Action so that it will leverage this functionality.