### PR TITLE
synchronize not synchronized?

### DIFF
--- a/filter/README.md
+++ b/filter/README.md
@@ -100,8 +100,8 @@ This also supports multiple actions.
 
 ```workflow
 action "action-filter" {
-  uses = "actions/bin/filter"
-  args = ["action", "opened|synchronized"]
+  uses = "actions/bin/filter@18d4c9c"
+  args = ["action", "opened|synchronize"]
 }
 ```
 


### PR DESCRIPTION
I admit this one always gets me - PRs are "opened" (past tense) or "synchronize" (present tense). Refer to `  "action": "synchronize",` in the webhook events.
But even so, this doc seems like every mention of a `uses = "actions/bin/filter"` is going to fail the syntax check for main.workflow - this is invalid syntax without the required `@18d4c9c`, no? That's what I get when I try this copied exactly.
But even when I tried to fix it up to pass the main.workflow syntax check, actions/bin/filter isn't working for me - is there some documentation somewhere that I could view or a working example anywhere?
```
action "Only open or sync" {
  uses = "actions/bin/filter@18d4c9c"
  args = ["action", "opened|synchronize"]
}
```
I get this error:
```
Removing intermediate container d80cf2ec3e65
 ---> 16a91fa314df
Successfully built 16a91fa314df
Successfully tagged gcr.io/gct-12-bp4ab3-ngovqnfjxcwuhw7f/2e035e5fb8ad977ee790ec390dcc01678860173c8af763469ce9edd9953e17f2/0c0528c9cdfbbd04f6b09b464de94fce116e820f638af7674f4ac129bf3d799a:5584c1714e6237e546ff9da7f6ee11d54fc9118ed57136ebba388cd6402deac3
Already have image: gcr.io/gct-12-bp4ab3-ngovqnfjxcwuhw7f/2e035e5fb8ad977ee790ec390dcc01678860173c8af763469ce9edd9953e17f2/0c0528c9cdfbbd04f6b09b464de94fce116e820f638af7674f4ac129bf3d799a:5584c1714e6237e546ff9da7f6ee11d54fc9118ed57136ebba388cd6402deac3
sh: 1: synchronize: not found
```