### PR TITLE
Filter Docs: update args in action example 

### DIFF
--- a/filter/README.md
+++ b/filter/README.md
@@ -101,7 +101,7 @@ Continue if the event payload includes a matching action.
 ```workflow
 action "action-filter" {
   uses = "actions/bin/filter@master"
-  args = "action synchronized"
+  args = "action synchronize"
 }
 ```
 
@@ -110,7 +110,7 @@ This also supports multiple actions.
 ```workflow
 action "action-filter" {
   uses = "actions/bin/filter@master"
-  args = ["action", "opened|synchronized"]
+  args = ["action", "opened|synchronize"]
 }
 ```
 


### PR DESCRIPTION
Closes https://github.com/actions/bin/issues/11.

This updates two instances of `synchronized` to `synchronize`, since a `synchronized` action doesn't currently exist for the [PullRequestEvent](https://developer.github.com/v3/activity/events/types/#pullrequestevent).