### PR TITLE
Add cURL

### DIFF
--- a/curl/Dockerfile
+++ b/curl/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:stable-slim
+
+LABEL "name"="curl"
+LABEL "maintainer"="GitHub Actions <support+actions@github.com>"
+LABEL "version"="1.0.0"
+
+LABEL "com.github.actions.name"="cURL for GitHub Actions"
+LABEL "com.github.actions.description"="Runs cURL in an Action"
+LABEL "com.github.actions.icon"="upload-cloud"
+LABEL "com.github.actions.color"="green"
+
+COPY LICENSE README.md THIRD_PARTY_NOTICE.md /
+
+COPY entrypoint.sh /entrypoint.sh
+
+RUN apt-get update && apt-get install curl -y
+
+ENTRYPOINT ["/entrypoint.sh"]
+

--- a/curl/LICENSE
+++ b/curl/LICENSE
@@ -1,0 +1,22 @@
+
+The MIT License (MIT)
+
+Copyright (c) 2018 GitHub, Inc. and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/curl/Makefile
+++ b/curl/Makefile
@@ -1,0 +1,18 @@
+include ../docker.mk
+include ../help.mk
+include ../shell.mk
+
+.PHONY: clean
+clean: ## Clean up after the build process.
+
+.PHONY: lint
+lint: shell-lint docker-lint ## Lint all of the files for this Action.
+
+.PHONY: build
+build: docker-build ## Build this Action.
+
+.PHONY: test
+test: ## Test the components of this Action.
+
+.PHONY: publish
+publish: docker-publish ## Publish this Action.

--- a/curl/README.md
+++ b/curl/README.md
@@ -1,0 +1,18 @@
+# curl
+
+## Usage
+
+Executes cURL with arguments listed in the Action's `args`.
+
+```
+action "Shell" {
+  uses = "actions/bin/curl@master"
+  args = ["github.com"]
+}
+```
+
+## License
+
+The Dockerfile and associated scripts and documentation in this project are released under the [MIT License](LICENSE).
+
+Container images built with this project include third party materials. See [THIRD_PARTY_NOTICE.md](THIRD_PARTY_NOTICE.md) for details.

--- a/curl/THIRD_PARTY_NOTICE.md
+++ b/curl/THIRD_PARTY_NOTICE.md
@@ -1,0 +1,13 @@
+# Third Party Notices and Information
+
+Container images built with this project include third party materials; see below for license and other copyright information.
+
+Certain open source code is available in container images, or online as noted below, or you may send a request for source code including identification of the container, the open source component name, and version number, to: `opensource@github.com`.
+
+Notwithstanding any other terms, you may reverse engineer this software to the extent required to debug changes to any libraries licensed under the GNU Lesser General Public License for your own use.
+
+## Debian packages
+
+License and other copyright information for each package is included in the image at `/usr/share/doc/{package}/copyright`.
+
+Source for each package is available at `https://packages.debian.org/source/{package}`.

--- a/curl/entrypoint.sh
+++ b/curl/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+sh -c "curl $*"


### PR DESCRIPTION
This action derived from `sh` might be useful for stuff like notifications. cURL is missing in the base Debian image but I would consider it as basic tool for many automations and tasks. What do you think?

I use it for slack webhooks. More examples may be interesting.