### PR TITLE
Filter: negate filter action

### DIFF
--- a/filter/bin/ref
+++ b/filter/bin/ref
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -14,6 +14,11 @@ case "$GITHUB_REF" in
     exit 0
     ;;
   *)
+    if [[ $(echo "$pattern" | sed -E "s/^([^/]*\/){2}//") == !* ]] && [[ $(echo "$pattern" | sed -E "s/^([^/]*\/){2}\!//") != $(echo "$GITHUB_REF" | sed -E "s/^([^/]*\/){2}//") ]];
+    then
+      echo "$GITHUB_REF matches $pattern"
+      exit 0
+    fi
     echo "$GITHUB_REF does not match $pattern"
     exit 78
 esac

--- a/filter/test/branch.bats
+++ b/filter/test/branch.bats
@@ -46,3 +46,22 @@ PATH="$PATH:$BATS_TEST_DIRNAME/../bin"
   [ "$status" -eq 0 ]
   [ "$output" = "refs/heads/the-masters-tournament matches refs/heads/*master*" ]
 }
+
+@test "branch: is a negation of substring" {
+  export GITHUB_REF=refs/heads/the-masters-tournament
+  run branch the-masters-tournament
+  [ "$status" -eq 0 ]
+  [ "$output" = "refs/heads/the-masters-tournament matches refs/heads/the-masters-tournament" ]
+
+  run branch !the-masters-tournament
+  [ "$status" -eq 78 ]
+  [ "$output" = "refs/heads/the-masters-tournament does not match refs/heads/!the-masters-tournament" ]
+  
+  run branch !master
+  [ "$status" -eq 0 ]
+  [ "$output" = "refs/heads/the-masters-tournament matches refs/heads/!master" ]
+
+  run branch master
+  [ "$status" -eq 78 ]
+  [ "$output" = "refs/heads/the-masters-tournament does not match refs/heads/master" ]
+}

--- a/filter/test/tag.bats
+++ b/filter/test/tag.bats
@@ -37,3 +37,22 @@ PATH="$PATH:$BATS_TEST_DIRNAME/../bin"
   [ "$status" -eq 78 ]
   [ "$output" = "refs/tags/v1.2.3 does not match refs/tags/release*" ]
 }
+
+@test "tag: ref is a negation of tag pattern" {
+  export GITHUB_REF=refs/tags/v1.2.3
+  run tag v1.2.3
+  [ "$status" -eq 0 ]
+  [ "$output" = "refs/tags/v1.2.3 matches refs/tags/v1.2.3" ]
+
+  run tag !v1.2.3
+  [ "$status" -eq 78 ]
+  [ "$output" = "refs/tags/v1.2.3 does not match refs/tags/!v1.2.3" ]
+
+  run tag !release
+  [ "$status" -eq 0 ]
+  [ "$output" = "refs/tags/v1.2.3 matches refs/tags/!release" ]
+  
+  run tag release
+  [ "$status" -eq 78 ]
+  [ "$output" = "refs/tags/v1.2.3 does not match refs/tags/release" ]
+}


### PR DESCRIPTION
Fixes #25 

Allows for ref to use a negation so that you can filter when a branch, tag, ref is not equal to the provided value. 

Example:
```
action "filter-to-exclude-branch-master" {
  uses = "actions/bin/filter@master"
  args = "branch !master"
}
```