### PR TITLE
bin/filter: Fix multiple action docs

### DIFF
--- a/filter/README.md
+++ b/filter/README.md
@@ -110,7 +110,7 @@ This also supports multiple actions.
 ```workflow
 action "action-filter" {
   uses = "actions/bin/filter@master"
-  args = ["action", "opened|synchronize"]
+  args = "action 'opened|synchronize'"
 }
 ```
 


### PR DESCRIPTION
Previously if you follow the docs for multiple actions,
you will get this error:

    sh: 1: synchronize: not found

This is because the arguments are sent through the bash shell.
The solution is to use a string args and quote the argument.