### PR TITLE
Support for pull request labels

### DIFF
--- a/filter/bin/label
+++ b/filter/bin/label
@@ -2,18 +2,23 @@
 
 set -e
 
-filter='select(.issue.labels!=null) | .issue.labels[].name'
+filter_issues='select(.issue.labels!=null) | .issue.labels[].name'
+filter_pullrequests='select(.pull_request.labels!=null) | .pull_request.labels[].name'
 
 if [ -z "$GITHUB_EVENT_PATH" ]; then
   echo "\$GITHUB_EVENT_PATH" not found
   exit 1
 fi
 
-matches=$(jq -r "$filter" "$GITHUB_EVENT_PATH")
+matches_issues=$(jq -r "$filter_issues" "$GITHUB_EVENT_PATH")
+matches_pullrequests=$(jq -r "$filter_pullrequests" "$GITHUB_EVENT_PATH")
 
 for label in "$@"; do
-  echo "$matches" | grep -Eq "^$label$" || {
-    echo "label \"$label\", does not match \"$matches\""
-    exit 78
+  echo "$matches_issues" | grep -Eq "^$label$" || {
+    echo "label \"$label\", does not match \"$(echo $matches_issues | paste -sd, -)\""
+    echo "$matches_pullrequests" | grep -Eq "^$label$" || {
+      echo "label \"$label\", does not match \"$(echo $matches_pullrequests | paste -sd, -)\""
+      exit 78
+    }
   }
 done

--- a/filter/bin/label
+++ b/filter/bin/label
@@ -2,7 +2,6 @@
 
 set -e
 
-filter_issues='select(.issue.labels!=null) | .issue.labels[].name'
 filter="([] + .issue.labels + .pull_request.labels)[].name"
 
 if [ -z "$GITHUB_EVENT_PATH" ]; then
@@ -10,15 +9,11 @@ if [ -z "$GITHUB_EVENT_PATH" ]; then
   exit 1
 fi
 
-matches_issues=$(jq -r "$filter_issues" "$GITHUB_EVENT_PATH")
-matches_pullrequests=$(jq -r "$filter_pullrequests" "$GITHUB_EVENT_PATH")
+matches=$(jq -r "$filter" "$GITHUB_EVENT_PATH")
 
 for label in "$@"; do
-  echo "$matches_issues" | grep -Eq "^$label$" || {
-    echo "label \"$label\", does not match \"$(echo $matches_issues | paste -sd, -)\""
-    echo "$matches_pullrequests" | grep -Eq "^$label$" || {
-      echo "label \"$label\", does not match \"$(echo $matches_pullrequests | paste -sd, -)\""
-      exit 78
-    }
+  echo "$matches" | grep -Eq "^$label$" || {
+    echo "label \"$label\", does not match \"$(echo $matches | paste -sd, -)\""
+    exit 78
   }
 done

--- a/filter/bin/label
+++ b/filter/bin/label
@@ -3,7 +3,7 @@
 set -e
 
 filter_issues='select(.issue.labels!=null) | .issue.labels[].name'
-filter_pullrequests='select(.pull_request.labels!=null) | .pull_request.labels[].name'
+filter="([] + .issue.labels + .pull_request.labels)[].name"
 
 if [ -z "$GITHUB_EVENT_PATH" ]; then
   echo "\$GITHUB_EVENT_PATH" not found

--- a/filter/test/fixtures/event.json
+++ b/filter/test/fixtures/event.json
@@ -14,6 +14,11 @@
     }
   },
   "pull_request": {
+    "labels": [
+      {
+        "name": "pr-urgent"
+      }
+    ],
     "user": {
       "login": "pr-user"
     }

--- a/filter/test/fixtures/pull_request_event.json
+++ b/filter/test/fixtures/pull_request_event.json
@@ -1,6 +1,6 @@
 {
   "action": "created",
-  "issue": {
+  "pull_request": {
     "labels": [
       {
         "name": "urgent"
@@ -10,7 +10,7 @@
       }
     ],
     "user": {
-      "login": "issue-user"
+      "login": "user"
     }
   }
 }

--- a/filter/test/label.bats
+++ b/filter/test/label.bats
@@ -11,6 +11,11 @@ export GITHUB_EVENT_PATH="$BATS_TEST_DIRNAME/fixtures/event.json"
   [ "$status" -eq 0 ]
 }
 
+@test "label: matches pr" {
+  run label pr-urgent
+  [ "$status" -eq 0 ]
+}
+
 @test "label: matches all" {
   run label urgent bug
   [ "$status" -eq 0 ]

--- a/filter/test/label.bats
+++ b/filter/test/label.bats
@@ -11,8 +11,8 @@ export GITHUB_EVENT_PATH="$BATS_TEST_DIRNAME/fixtures/event.json"
   [ "$status" -eq 0 ]
 }
 
-@test "label: matches pr" {
-  run label pr-urgent
+@test "label: matches pull request" {
+  export GITHUB_EVENT_PATH="$BATS_TEST_DIRNAME/fixtures/pull_request_event.json" run label urgent
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
As the documentation states it support to define a filter action on a label of a pull request. Currently this only works when it's an issue.

[Documentation](https://github.com/actions/bin/tree/master/filter#label) `Continue if the issue or pull request has the following label`

This pull request add the possibility to use the filter on pull requests as well.