### PR TITLE
Add deleted filter

### DIFF
--- a/filter/README.md
+++ b/filter/README.md
@@ -38,6 +38,17 @@ action "Publish" {
 
 ## Available filters
 
+### deleted
+
+Continue if the event deletes a branch or tag.
+
+```workflow
+action "tag-filter" {
+  uses = "actions/bin/filter@master"
+  args = "deleted"
+}
+```
+
 ### tag
 
 Continue if the event is a tag.

--- a/filter/README.md
+++ b/filter/README.md
@@ -43,7 +43,7 @@ action "Publish" {
 Continue if the event deletes a branch or tag.
 
 ```workflow
-action "tag-filter" {
+action "deleted-filter" {
   uses = "actions/bin/filter@master"
   args = "deleted"
 }

--- a/filter/bin/deleted
+++ b/filter/bin/deleted
@@ -2,8 +2,6 @@
 
 set -e
 
-pattern="${1:-*}"
-
 if [ -z "$GITHUB_EVENT_PATH" ]; then
   echo "\$GITHUB_EVENT_PATH is not set"
   exit 1

--- a/filter/bin/deleted
+++ b/filter/bin/deleted
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+
+pattern="${1:-*}"
+
+if [ -z "$GITHUB_EVENT_PATH" ]; then
+  echo "\$GITHUB_EVENT_PATH is not set"
+  exit 1
+fi
+
+DELETED="$(jq '.deleted' < "$GITHUB_EVENT_PATH")"
+if [ "$DELETED" != "true" ]; then
+  echo "Event does not delete a branch or tag."
+  exit 78
+fi

--- a/filter/test/deleted.bats
+++ b/filter/test/deleted.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+load bootstrap
+
+PATH="$PATH:$BATS_TEST_DIRNAME/../bin"
+
+@test "deleted: without an event file" {
+  unset GITHUB_EVENT_PATH
+  run deleted
+  [ "$status" -eq 1 ]
+  [ "$output" = "\$GITHUB_EVENT_PATH is not set" ]
+}
+
+@test "deleted: event deletes a branch" {
+  export GITHUB_EVENT_PATH="$BATS_TEST_DIRNAME/fixtures/delete_branch_event.json"
+  run deleted
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}
+
+@test "deleted: event deletes a tag" {
+  export GITHUB_EVENT_PATH="$BATS_TEST_DIRNAME/fixtures/delete_tag_event.json"
+  run deleted
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}
+
+@test "deleted: not delete event" {
+  export GITHUB_EVENT_PATH="$BATS_TEST_DIRNAME/fixtures/empty_event.json"
+  run deleted
+  [ "$status" -eq 78 ]
+  [ "$output" = "Event does not delete a branch or tag." ]
+}


### PR DESCRIPTION
This PR adds an easy way to filter delete events.

Previously, I had created my own [action](https://github.com/UltCombo/action-filter-deleted-branches) to handle this case even before the `not` filter was implemented here. Now, I thought it was time to deprecate my action and use `not deleted_branch` and `not deleted_tag` filters, but I noticed they are currently broken (#50) and adding two filter actions for such simple functionality seemed a bit clunky.

Therefore, I propose a simple alternative way to filter all delete events.