### PR TITLE
Adds a merged filter 

### DIFF
--- a/filter/README.md
+++ b/filter/README.md
@@ -211,6 +211,25 @@ action "environment-filter" {
   args = ["environment", "staging", "production"]
 }
 ```
+### merged
+
+Continue if the pull request is merged & closed.
+
+```workflow
+action "merged-filter" {
+  uses = "actions/bin/filter@master"
+  args = "merged true"
+}
+```
+
+Continue if the pull request is closed with unmerged commits.
+
+```workflow
+action "merged-filter" {
+  uses = "actions/bin/filter@master"
+  args = "merged false"
+}
+```
 
 ## License
 

--- a/filter/bin/merged
+++ b/filter/bin/merged
@@ -2,10 +2,7 @@
 
 set -e
 
-if [ -z "$GITHUB_EVENT_PATH" ]; then
-  echo "\$GITHUB_EVENT_PATH" not found
-  exit 1
-fi
+action closed
 
 expected="$1"
 actual=$(jq -r .pull_request.merged "$GITHUB_EVENT_PATH")

--- a/filter/bin/merged
+++ b/filter/bin/merged
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+
+if [ -z "$GITHUB_EVENT_PATH" ]; then
+  echo "\$GITHUB_EVENT_PATH" not found
+  exit 1
+fi
+
+expected="$1"
+actual=$(jq -r .merged "$GITHUB_EVENT_PATH")
+
+echo "$actual" | grep -Eq "^$expected$" || {
+  echo "merged is \"$actual\", not \"$expected\""
+  exit 78
+}

--- a/filter/bin/merged
+++ b/filter/bin/merged
@@ -2,7 +2,7 @@
 
 set -e
 
-exec action closed
+action closed
 
 expected="$1"
 actual=$(jq -r .pull_request.merged "$GITHUB_EVENT_PATH")

--- a/filter/bin/merged
+++ b/filter/bin/merged
@@ -8,7 +8,7 @@ if [ -z "$GITHUB_EVENT_PATH" ]; then
 fi
 
 expected="$1"
-actual=$(jq -r .merged "$GITHUB_EVENT_PATH")
+actual=$(jq -r .pull_request.merged "$GITHUB_EVENT_PATH")
 
 echo "$actual" | grep -Eq "^$expected$" || {
   echo "merged is \"$actual\", not \"$expected\""

--- a/filter/bin/merged
+++ b/filter/bin/merged
@@ -2,7 +2,7 @@
 
 set -e
 
-action closed
+exec action closed
 
 expected="$1"
 actual=$(jq -r .pull_request.merged "$GITHUB_EVENT_PATH")

--- a/filter/test/fixtures/pull_request_event.json
+++ b/filter/test/fixtures/pull_request_event.json
@@ -1,5 +1,5 @@
 {
-  "action": "created",
+  "action": "closed",
   "pull_request": {
     "merged": "false",
     "labels": [

--- a/filter/test/fixtures/pull_request_event.json
+++ b/filter/test/fixtures/pull_request_event.json
@@ -1,5 +1,6 @@
 {
   "action": "created",
+  "merged": "false",
   "pull_request": {
     "labels": [
       {

--- a/filter/test/fixtures/pull_request_event.json
+++ b/filter/test/fixtures/pull_request_event.json
@@ -1,7 +1,7 @@
 {
   "action": "created",
-  "merged": "false",
   "pull_request": {
+    "merged": "false",
     "labels": [
       {
         "name": "urgent"

--- a/filter/test/merged.bats
+++ b/filter/test/merged.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+load bootstrap
+
+PATH="$PATH:$BATS_TEST_DIRNAME/../bin"
+
+export GITHUB_EVENT_PATH="$BATS_TEST_DIRNAME/fixtures/pull_request_event.json"
+
+@test "merged: matches" {
+  run merged false
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}
+
+@test "merged: does not match" {
+  run merged true
+  [ "$status" -eq 78 ]
+  [ "$output" = "merged is \"false\", not \"true\"" ]
+}
+
+@test "merged: matches a or b" {
+  run merged "true|false"
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}
+
+@test "merged: does not match a or b" {
+  run merged "edited|deleted"
+  [ "$status" -eq 78 ]
+  [ "$output" = "merged is \"false\", not \"edited|deleted\"" ]
+}


### PR DESCRIPTION
Inspired by #52 
Workflow authors can use this filter to check the value of the "merged" field in a PullRequestEvent
Webhook payload to further run actions if a Pull Request is merged or closed without merging.

