### PR TITLE
Fix typo action name in README

### DIFF
--- a/filter/README.md
+++ b/filter/README.md
@@ -186,7 +186,7 @@ action "actor-filter" {
 Used to provide the logical opposite of other filters.
 
 ```workflow
-action "tag-filter" {
+action "not-filter" {
   uses = "actions/bin/filter@master"
   args = "not actor octocat"
 }


### PR DESCRIPTION
Changed `tag-filter` -> `not-filter` 