### PR TITLE
Fix debug action usage example

### DIFF
--- a/debug/README.md
+++ b/debug/README.md
@@ -13,7 +13,7 @@ workflow "Launch the rescue mission" {
 }
 
 action "debug" {
-  uses = "actions/bin/debug"
+  uses = "actions/bin/debug@master"
 }
 ```
 


### PR DESCRIPTION
Using only `uses = "actions/bin/debug"` will create parsing error, leading to Invalid Workflow error.

Signed-off-by: Riddhesh Sanghvi <riddheshsanghvi96@gmail.com>